### PR TITLE
WIP: Netpoller for noos

### DIFF
--- a/src/embedded/rtos/event.go
+++ b/src/embedded/rtos/event.go
@@ -21,6 +21,7 @@ type Cond struct {
 	seq  uintptr
 	lock uintptr // FIXME mutex size?
 	link uintptr
+	self *Cond
 }
 
 // Wait waits on the Cond to become true and consumes it by setting it back to

--- a/src/embedded/rtos/event.go
+++ b/src/embedded/rtos/event.go
@@ -1,0 +1,38 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rtos
+
+import (
+	"time"
+	_ "unsafe"
+)
+
+// Cond allows to communicate the occurrence of an event.
+//
+// Exactly one goroutine can call Wait but it is allowed for multiple goroutines
+// or interrupt handlers to call Signal.
+//
+// A Cond must not be copied after first use.
+type Cond struct {
+	// must be in sync with runtime.pollDesc
+	key  uintptr
+	seq  uintptr
+	lock uintptr // FIXME mutex size?
+	link uintptr
+}
+
+// Wait waits on the Cond to become true and consumes it by setting it back to
+// false. If there previously was a call to Signal Wait returns immediately.
+// Returns whether the Cond became true during the call.
+func (n *Cond) Wait(timeout time.Duration) bool { return condwait(n, int64(timeout)) }
+
+// Signal sets the Cond to true.
+func (n *Cond) Signal() { condsignal(n) }
+
+//go:linkname condsignal runtime.rtos_condsignal
+func condsignal(n *Cond)
+
+//go:linkname condwait runtime.rtos_condwait
+func condwait(n *Cond, timeout int64) bool

--- a/src/runtime/netpoll_noos.go
+++ b/src/runtime/netpoll_noos.go
@@ -100,7 +100,8 @@ func netpollblock(pd *pollDesc, ns int64) bool {
 		gp.timer = t
 	}
 	t.f = netpolldeadline
-	t.arg = pd
+	pd.self = pd
+	t.arg = pd.makeArg()
 	t.seq = pd.seq
 	if ns < 0 {
 		t.nextwhen = maxWhen
@@ -248,12 +249,17 @@ func rtos_condsignal(n *pollDesc) {
 	}
 }
 
+// Network poller descriptor.
+//
+// No heap pointers.
 type pollDesc struct {
+	// must be in sync with embedded/rtos.Cond
 	_    sys.NotInHeap
 	g    atomic.Uintptr
 	seq  uintptr
 	lock mutex // protects seq
 	link atomic.Uintptr
+	self *pollDesc // storage for indirect interface. See (*pollDesc).makeArg.
 }
 
 //go:nosplit
@@ -287,3 +293,16 @@ func (l *pollList) insert(n *pollDesc) bool {
 func (l *pollList) free() *pollDesc {
 	return (*pollDesc)(unsafe.Pointer(l.head.Swap(0)))
 }
+
+// Helps to avoid heap escape. See comment of same function in netpoll.go
+func (pd *pollDesc) makeArg() (i any) {
+	x := (*eface)(unsafe.Pointer(&i))
+	x._type = pdType
+	x.data = unsafe.Pointer(&pd.self)
+	return
+}
+
+var (
+	pdEface any    = (*pollDesc)(nil)
+	pdType  *_type = efaceOf(&pdEface)._type
+)

--- a/src/runtime/netpoll_noos.go
+++ b/src/runtime/netpoll_noos.go
@@ -80,10 +80,12 @@ const (
 // netpollblock parks the goroutine on pd.  It returns whether the note was
 // woken up in the timeout specified by ns.
 func netpollblock(pd *pollDesc, ns int64) bool {
+	var gp *g
+	var t *timer
 	gpp := &pd.g
 
-	if ns <= 0 {
-		return gpp.Load() == pdReady
+	if ns == 0 {
+		goto clear
 	}
 
 	lock(&pd.lock)
@@ -91,8 +93,8 @@ func netpollblock(pd *pollDesc, ns int64) bool {
 	unlock(&pd.lock)
 
 	// configure deadline timer
-	gp := getg()
-	t := gp.timer
+	gp = getg()
+	t = gp.timer
 	if t == nil {
 		t = new(timer)
 		gp.timer = t
@@ -111,7 +113,8 @@ func netpollblock(pd *pollDesc, ns int64) bool {
 
 	// set the gpp semaphore to pdWait
 	for {
-		if gpp.Load() == pdReady {
+		// Consume notification if already ready.
+		if gpp.CompareAndSwap(pdReady, pdNil) {
 			return true
 		}
 		if gpp.CompareAndSwap(pdNil, pdWait) {
@@ -127,7 +130,9 @@ func netpollblock(pd *pollDesc, ns int64) bool {
 
 	gopark(netpollblockcommit, unsafe.Pointer(gpp), waitReasonIOWait, traceBlockNet, 5)
 
-	old := gpp.Load()
+clear:
+	// be careful to not lose concurrent pdReady notification
+	old := gpp.Swap(pdNil)
 	if old > pdWait {
 		throw("runtime: corrupted polldesc")
 	}

--- a/src/runtime/netpoll_noos.go
+++ b/src/runtime/netpoll_noos.go
@@ -8,6 +8,7 @@ package runtime
 
 import (
 	"runtime/internal/atomic"
+	"runtime/internal/sys"
 	"unsafe"
 )
 
@@ -43,11 +44,10 @@ func netpoll(delay int64) (toRun gList, delta int32) {
 		notetsleep(&netpollNote, delay)
 	}
 
-	n := wakerq.removeall()
+	n := wakerq.free()
 	for n != nil {
-		next := n.release()
 		delta += netpollready(&toRun, n)
-		n = next
+		n = n.pop()
 	}
 
 	unlock(&netpollStubLock)
@@ -235,9 +235,7 @@ func rtos_condsignal(n *pollDesc) {
 		}
 	}
 
-	if n.acquire() {
-		wakerq.insert(n)
-
+	if wakerq.insert(n) {
 		if isr() {
 			if !atomic.Cas(key32(&netpollNote.key), 0, 1) {
 				return
@@ -250,77 +248,42 @@ func rtos_condsignal(n *pollDesc) {
 	}
 }
 
-// eventlist
-
-// pollDesc is a event that contains a link field to construct linked lists of
-// events
 type pollDesc struct {
+	_    sys.NotInHeap
 	g    atomic.Uintptr
 	seq  uintptr
 	lock mutex // protects seq
-	link pollp
+	link atomic.Uintptr
 }
 
 //go:nosplit
-func (n *pollDesc) acquire() bool {
-	return (&n.link).atomicCAS(0, 1)
-}
-
-//go:nosplit
-func (n *pollDesc) release() *pollDesc {
-	next := n.link
-	atomic.Storeuintptr((*uintptr)(&n.link), 0)
-	return next.ptr()
-}
-
-//go:nosplit
-func (n *pollDesc) pollp() pollp { return pollp(unsafe.Pointer(n)) }
-
-type pollp uintptr
-
-//go:nosplit
-func (n pollp) ptr() *pollDesc { return (*pollDesc)(unsafe.Pointer(n)) }
-
-//go:nosplit
-func (p *pollp) atomicLoad() pollp {
-	return pollp(atomic.Loaduintptr((*uintptr)(p)))
-}
-
-//go:nosplit
-func (p *pollp) atomicCAS(old, new pollp) bool {
-	return atomic.Casuintptr((*uintptr)(p), uintptr(old), uintptr(new))
+func (n *pollDesc) pop() *pollDesc {
+	next := n.link.Swap(0)
+	return (*pollDesc)(unsafe.Pointer(next))
 }
 
 type pollList struct {
-	head pollp
+	head atomic.Uintptr
 }
 
-// insert inserts n at the beginning of l. You must acquire n before insert it.
+// insert inserts n at the beginning of l if it isn't already
 //
 //go:nosplit
-func (l *pollList) insert(n *pollDesc) {
-	if n.link != 1 {
-		for {
-			breakpoint()
-		}
+func (l *pollList) insert(n *pollDesc) bool {
+	if !n.link.CompareAndSwap(0, 1) {
+		return false
 	}
 	for {
-		head := (&l.head).atomicLoad()
-		n.link = head
-		if (&l.head).atomicCAS(head, n.pollp()) {
-			return
+		head := l.head.Load()
+		n.link.Store(head)
+		if l.head.CompareAndSwap(head, uintptr(unsafe.Pointer(n))) {
+			break
 		}
 	}
+	return true
 }
 
-// removeall removes and returns the whole content of l.
-//
 //go:nosplit
-func (l *pollList) removeall() *pollDesc {
-	for {
-		head := (&l.head).atomicLoad()
-		if (&l.head).atomicCAS(head, 0) {
-			return head.ptr()
-		}
-	}
+func (l *pollList) free() *pollDesc {
+	return (*pollDesc)(unsafe.Pointer(l.head.Swap(0)))
 }

--- a/src/runtime/netpoll_noos.go
+++ b/src/runtime/netpoll_noos.go
@@ -1,0 +1,321 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build noos
+
+package runtime
+
+import (
+	"runtime/internal/atomic"
+	"unsafe"
+)
+
+var netpollInited atomic.Uint32
+var netpollWaiters atomic.Uint32
+
+var netpollStubLock mutex
+var netpollNote note
+
+var wakerq pollList
+
+func netpollGenericInit() {
+	netpollInited.Store(1)
+}
+
+func netpollBreak() {
+	// do not use notewakeup, we allow multiple wakeups for this note
+	if !atomic.Cas(key32(&netpollNote.key), 0, 1) {
+		return
+	}
+	futexwakeup(key32(&netpollNote.key), 1)
+	return
+}
+
+// Polls for goroutines waiting on interrupts.
+// Returns list of goroutines that become runnable.
+func netpoll(delay int64) (toRun gList, delta int32) {
+	// This lock ensures that only one goroutine tries to use
+	// the note. It should normally be completely uncontended.
+	lock(&netpollStubLock)
+
+	if !atomic.Cas(key32(&netpollNote.key), 1, 0) { // try noteclear
+		notetsleep(&netpollNote, delay)
+	}
+
+	n := wakerq.removeall()
+	for n != nil {
+		next := n.release()
+		delta += netpollready(&toRun, n)
+		n = next
+	}
+
+	unlock(&netpollStubLock)
+
+	return
+}
+
+func netpollinited() bool {
+	return netpollInited.Load() != 0
+}
+
+// netpollAnyWaiters reports whether any goroutines are waiting for I/O.
+func netpollAnyWaiters() bool {
+	return netpollWaiters.Load() > 0
+}
+
+// netpollAdjustWaiters adds delta to netpollWaiters.
+func netpollAdjustWaiters(delta int32) {
+	if delta != 0 {
+		netpollWaiters.Add(delta)
+	}
+}
+
+const (
+	pdNil   uintptr = 0
+	pdReady uintptr = 1
+	pdWait  uintptr = 2
+)
+
+// netpollblock parks the goroutine on pd.  It returns whether the note was
+// woken up in the timeout specified by ns.
+func netpollblock(pd *pollDesc, ns int64) bool {
+	gpp := &pd.g
+
+	if ns <= 0 {
+		return gpp.Load() == pdReady
+	}
+
+	lock(&pd.lock)
+	pd.seq++
+	unlock(&pd.lock)
+
+	// configure deadline timer
+	gp := getg()
+	t := gp.timer
+	if t == nil {
+		t = new(timer)
+		gp.timer = t
+	}
+	t.f = netpolldeadline
+	t.arg = pd
+	t.seq = pd.seq
+	if ns < 0 {
+		t.nextwhen = maxWhen
+	} else {
+		t.nextwhen = nanotime() + ns
+		if t.nextwhen < 0 { // check for overflow.
+			t.nextwhen = maxWhen
+		}
+	}
+
+	// set the gpp semaphore to pdWait
+	for {
+		if gpp.Load() == pdReady {
+			return true
+		}
+		if gpp.CompareAndSwap(pdNil, pdWait) {
+			break
+		}
+
+		// Double check that this isn't corrupt; otherwise we'd loop
+		// forever.
+		if v := gpp.Load(); v != pdReady && v != pdNil {
+			throw("runtime: double wait")
+		}
+	}
+
+	gopark(netpollblockcommit, unsafe.Pointer(gpp), waitReasonIOWait, traceBlockNet, 5)
+
+	old := gpp.Load()
+	if old > pdWait {
+		throw("runtime: corrupted polldesc")
+	}
+	return old == pdReady
+}
+
+func netpollblockcommit(gp *g, gpp unsafe.Pointer) bool {
+	r := atomic.Casuintptr((*uintptr)(gpp), pdWait, uintptr(unsafe.Pointer(gp)))
+	resettimer(gp.timer, gp.timer.nextwhen)
+	if r {
+		netpollAdjustWaiters(1)
+	}
+	return r
+}
+
+// netpollunblock moves pd.g depending on ioready into the pdNil or pdReady
+// state. This returns any goroutine blocked on pd.g. It adds any adjustment to
+// netpollWaiters to *delta; this adjustment should be applied after the
+// goroutine has been marked ready.
+func netpollunblock(pd *pollDesc, ioready bool, delta *int32) *g {
+	gpp := &pd.g
+
+	for {
+		old := gpp.Load()
+		if old == pdReady {
+			return nil
+		}
+		if old == pdNil && !ioready {
+			return nil
+		}
+		new := pdNil
+		if ioready {
+			new = pdReady
+		}
+		if gpp.CompareAndSwap(old, new) {
+			if old == pdWait {
+				old = pdNil
+			} else if old != pdNil {
+				*delta -= 1
+			}
+			return (*g)(unsafe.Pointer(old))
+		}
+	}
+}
+
+// netpollready declares that the g associated with pd is ready to run. The
+// toRun argument is used to build a list of goroutines to return from netpoll.
+//
+// This returns a delta to apply to netpollWaiters.
+//
+// This may run while the world is stopped, so write barriers are not allowed.
+//
+//go:nowritebarrier
+func netpollready(toRun *gList, pd *pollDesc) (delta int32) {
+	gp := netpollunblock(pd, true, &delta)
+	if gp != nil {
+		toRun.push(gp)
+	}
+	return
+}
+
+// netpolldeadline is the deadline timers callback.
+func netpolldeadline(arg any, seq uintptr) {
+	pd := arg.(*pollDesc)
+
+	lock(&pd.lock)
+
+	if pd.seq != seq {
+		unlock(&pd.lock)
+		return // timer is stale, ignore
+	}
+
+	delta := int32(0)
+	gp := netpollunblock(pd, false, &delta)
+	unlock(&pd.lock)
+	if gp != nil {
+		goready(gp, 1)
+	}
+	netpollAdjustWaiters(delta)
+}
+
+func rtos_condwait(n *pollDesc, timeout int64) bool {
+	return netpollblock(n, timeout)
+}
+
+// rtos_condsignal wakes up the netpoller if a goroutine is waiting or in
+// pdWait.  Otherwise it only sets the event to pdReady.
+//
+//go:nowritebarrierrec
+//go:nosplit
+func rtos_condsignal(n *pollDesc) {
+	for {
+		old := n.g.Load()
+		if old < pdWait {
+			if n.g.CompareAndSwap(old, pdReady) {
+				return
+			}
+		} else {
+			break
+		}
+	}
+
+	if n.acquire() {
+		wakerq.insert(n)
+
+		if isr() {
+			if !atomic.Cas(key32(&netpollNote.key), 0, 1) {
+				return
+			}
+			curcpu().wakeNetpoller = true
+			curcpuWakeup()
+		} else {
+			netpollBreak()
+		}
+	}
+}
+
+// eventlist
+
+// pollDesc is a event that contains a link field to construct linked lists of
+// events
+type pollDesc struct {
+	g    atomic.Uintptr
+	seq  uintptr
+	lock mutex // protects seq
+	link pollp
+}
+
+//go:nosplit
+func (n *pollDesc) acquire() bool {
+	return (&n.link).atomicCAS(0, 1)
+}
+
+//go:nosplit
+func (n *pollDesc) release() *pollDesc {
+	next := n.link
+	atomic.Storeuintptr((*uintptr)(&n.link), 0)
+	return next.ptr()
+}
+
+//go:nosplit
+func (n *pollDesc) pollp() pollp { return pollp(unsafe.Pointer(n)) }
+
+type pollp uintptr
+
+//go:nosplit
+func (n pollp) ptr() *pollDesc { return (*pollDesc)(unsafe.Pointer(n)) }
+
+//go:nosplit
+func (p *pollp) atomicLoad() pollp {
+	return pollp(atomic.Loaduintptr((*uintptr)(p)))
+}
+
+//go:nosplit
+func (p *pollp) atomicCAS(old, new pollp) bool {
+	return atomic.Casuintptr((*uintptr)(p), uintptr(old), uintptr(new))
+}
+
+type pollList struct {
+	head pollp
+}
+
+// insert inserts n at the beginning of l. You must acquire n before insert it.
+//
+//go:nosplit
+func (l *pollList) insert(n *pollDesc) {
+	if n.link != 1 {
+		for {
+			breakpoint()
+		}
+	}
+	for {
+		head := (&l.head).atomicLoad()
+		n.link = head
+		if (&l.head).atomicCAS(head, n.pollp()) {
+			return
+		}
+	}
+}
+
+// removeall removes and returns the whole content of l.
+//
+//go:nosplit
+func (l *pollList) removeall() *pollDesc {
+	for {
+		head := (&l.head).atomicLoad()
+		if (&l.head).atomicCAS(head, 0) {
+			return head.ptr()
+		}
+	}
+}

--- a/src/runtime/netpoll_stub.go
+++ b/src/runtime/netpoll_stub.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build noos || plan9
+//go:build plan9
 
 package runtime
 

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -3740,7 +3740,7 @@ func wakeNetPoller(when int64) {
 	} else {
 		// There are no threads in the network poller, try to get
 		// one there so it can handle new timers.
-		if GOOS != "plan9" { // Temporary workaround - see issue #42303.
+		if GOOS != "plan9" && GOOS != "noos" { // Temporary workaround - see issue #42303.
 			wakep()
 		}
 	}

--- a/src/runtime/tasker_noos.go
+++ b/src/runtime/tasker_noos.go
@@ -91,16 +91,17 @@ var thetasker = tasker{
 const fbnum = 4 // number of futex hash table buckets, must be power of two
 
 type cpuctx struct {
-	_        sys.NotInHeap
-	gh       g               // for ISRs, must be the first field in this struct
-	t        *tasker         // points to thetasker
-	exe      muintptr        // m currently executed by CPU
-	newexe   bool            // for architecture-dependent code: exe changed
-	schedule bool            // for architecture-dependent code: run scheduler
-	runnable mq              // threads in runnable state
-	waitingt msl             // threads waiting until some time elapses
-	wakerq   [fbnum]notelist // futex wakeup request from interrupt handlers
-	mh       m               // for ISRs, mostly not written so works as cache line pad
+	_             sys.NotInHeap
+	gh            g               // for ISRs, must be the first field in this struct
+	t             *tasker         // points to thetasker
+	exe           muintptr        // m currently executed by CPU
+	newexe        bool            // for architecture-dependent code: exe changed
+	schedule      bool            // for architecture-dependent code: run scheduler
+	runnable      mq              // threads in runnable state
+	waitingt      msl             // threads waiting until some time elapses
+	wakerq        [fbnum]notelist // futex wakeup request from interrupt handlers
+	wakeNetpoller bool            // netpoller wakeup request from interrupt handlers
+	mh            m               // for ISRs, mostly not written so works as cache line pad
 }
 
 // id returns CPU identifier. It must be a positive integer from 0 to the
@@ -243,6 +244,12 @@ func curcpuRunScheduler() {
 				taskerFutexwakeup(&curcpu.t.waitingf[i], key32(&n.key), 1)
 				n = next
 			}
+		}
+		if curcpu.wakeNetpoller {
+			nn := &netpollNote
+			fb := fhash(uintptr(unsafe.Pointer(&nn.key)))
+			taskerFutexwakeup(&curcpu.t.waitingf[fb], key32(&nn.key), 1)
+			curcpu.wakeNetpoller = false
 		}
 
 		var nextschedt int64


### PR DESCRIPTION
Makes the wakerq global and consumed by a minimal netpoller implementation. The netpoller uses the same sync mechanics as the common netpoller.go implementation. It has one additional state that protects against false wakeup, if a note is enqueued during a Clear.

This is a performance optimization. The current rtos.Note implementation goes into a blocking syscall on every Sleep call, causing an expensive handoff (~800us CPU time on N64). Using the netpoller instead allow to use an ordinary goroutine sleep instead.

The need for this arised while implementing a driver for an DMA controller. Interrupts might trigger every few milliseceonds, which is too long to wait but also too short to sleep on a Note if it eats almost a whole millisecond of CPU time.

TODO
- [x]  Move to netpoller_noos.go
- [ ]  Maybe avoid need for mutex?
- [ ]  Don't reuse the time.Sleep timer?
- [ ]  Testing