### PR TITLE
mips64: Various trivial fixes

### DIFF
--- a/src/embedded/rtos/irq_noos_mips64.go
+++ b/src/embedded/rtos/irq_noos_mips64.go
@@ -4,6 +4,8 @@
 
 package rtos
 
+import _ "unsafe"
+
 const (
 	intPrioHighest = 1
 	intPrioHigh    = 1

--- a/src/runtime/mem_noos.go
+++ b/src/runtime/mem_noos.go
@@ -49,7 +49,7 @@ func meminit(freeStart, freeEnd, nodmaStart, nodmaEnd, stackTop uintptr) (nodmaS
 	// heuristic relationship with something more strict.
 	const (
 		A = unsafe.Sizeof(emptymspan) / 2
-		B = unsafe.Sizeof(uintptr(0)) * 1024
+		B = unsafe.Sizeof(uintptr(0)) * 1024 * 8
 	)
 	palloc := A*(freeSize>>pageShift) + B
 

--- a/src/runtime/sys_noos_mips64.s
+++ b/src/runtime/sys_noos_mips64.s
@@ -55,7 +55,7 @@ TEXT ·setprivlevel(SB),NOSPLIT|NOFRAME,$0-24
 	RET
 
 // func bind(cpuid int) (oldcpuid, errno int)
-TEXT ·setprivlevel(SB),NOSPLIT|NOFRAME,$0-24
+TEXT ·bind(SB),NOSPLIT|NOFRAME,$0-24
 	MOVV  $SYS_bind, R8
 	MOVV  $(8+8), R9
 	MOVV  $16, R10


### PR DESCRIPTION
Two of these just fix compile errors that sneaked in while I was on vacation ;)

The changes done to `meminit()` made the gopher-kart example panic before the gameloop starts:

    fatal error: runtime: cannot allocate memory

For now I just increased palloc until it was stable.  This change also affects thumb targets, maybe a target specific constant is necessary. The TODO above that code remains.