### PR TITLE
mips64: Fix irqprio for syscalls in interrupt

### DIFF
--- a/src/runtime/tasker_noos_mips64.s
+++ b/src/runtime/tasker_noos_mips64.s
@@ -419,10 +419,6 @@ fatal:
 
 TEXT runtime·exceptionReturn(SB),NOSPLIT|NOFRAME,$0
 	MOVV  _mstatus(R29), R26
-	AND   $~INTR_EXT, R26
-	MOVW  ·globalIRQMask(SB), R27
-	AND   $INTR_EXT, R27
-	OR    R27, R26
 	MOVV  R26, M(C0_SR)
 	MOVV  _lr(R29), R31
 	AND   $~1, R31 // Remove smallCtx flag from lr


### PR DESCRIPTION
The globalIRQMask should only be restored when we are returning back to thread mode. The externalInterruptHandler will temporarily mask low-prio interrupts without updating globalIRQMask. If the user implemented handler invokes a fast syscall, it must not restore the globalIRQMask but the irq mask from the exception context.